### PR TITLE
Add WhatsApp invite tests

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+// Cleanup after each test
+afterEach(() => {
+  cleanup();
+});
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock IntersectionObserver
+global.IntersectionObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock navigator
+Object.defineProperty(window, 'navigator', {
+  writable: true,
+  value: {
+    geolocation: {
+      getCurrentPosition: vi.fn(),
+      watchPosition: vi.fn(),
+      clearWatch: vi.fn(),
+    },
+    onLine: true,
+  },
+});
+
+// Mock Notification API
+Object.defineProperty(window, 'Notification', {
+  writable: true,
+  value: {
+    permission: 'default',
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+  },
+}); 

--- a/src/tests/send-whatsapp-invite.test.ts
+++ b/src/tests/send-whatsapp-invite.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { apiClient } from '@/services/APIClient';
+
+// Utility to mock fetch responses
+function mockFetch(response: any, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(response),
+    statusText: ok ? 'OK' : 'Bad Request'
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('apiClient.notifications.sendWhatsAppInvite', () => {
+  it('returns WhatsApp URL when phone and message provided', async () => {
+    const whatsappUrl = 'https://wa.me/250123456?text=hello';
+    global.fetch = mockFetch({ success: true, whatsapp_url: whatsappUrl });
+
+    const result = await apiClient.notifications.sendWhatsAppInvite('+250123456', 'hello');
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    // result may be returned directly or wrapped in data
+    const url = (result as any).whatsapp_url || (result as any).data?.whatsapp_url;
+    expect(url).toBe(whatsappUrl);
+  });
+
+  it('handles missing parameters gracefully', async () => {
+    global.fetch = mockFetch({}, false);
+
+    const result = await apiClient.notifications.sendWhatsAppInvite('', '');
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe('Bad Request');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,6 @@ export default defineConfig(({ mode }) => ({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: './src/tests/setup.ts',
+    setupFiles: './src/test/setup.ts',
   },
 }));


### PR DESCRIPTION
## Summary
- restore test setup utilities
- test `apiClient.notifications.sendWhatsAppInvite`
- point Vite test config to correct setup file

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cdad0368483258c955c01f537d53d